### PR TITLE
🛠️FIX : Contact us page name field validation added

### DIFF
--- a/src/Pages/contact.js
+++ b/src/Pages/contact.js
@@ -80,6 +80,7 @@ function Contact() {
           value={formData.name}
           onChange={handleChange}
           required
+          pattern="[a-zA-Z\s]+" title="Name must only contain letters"
         />
         <Input
           type="email"


### PR DESCRIPTION
## What does this PR do?

On the Contact Us page name field validation is added. now, the name field only accepts alphabets.

# Fixes #49 
# Closes #65 , #49 



## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Screenshots 

![image](https://github.com/user-attachments/assets/99737e9f-077c-4712-adbf-105d4fa0adaf)



## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent-sized PR without self-review might be rejected.