### PR TITLE
Added Twitter and Github icons' native colors while hovering over them at footer

### DIFF
--- a/src/componets/footer.js
+++ b/src/componets/footer.js
@@ -130,6 +130,10 @@ const SocialIcon = styled(motion.a)`
     color: #0077b5; /* LinkedIn Blue */
   }
 
+  &[href*="github.com"]:hover {
+    color: #1C2025; /* GitHub Black */
+  }
+
   @media (max-width: 768px) {
     font-size: 1.3rem;
   }
@@ -173,11 +177,11 @@ function Footer() {
           </SocialIcon>
 
           <SocialIcon
-            href="https://linkedin.com"
+            href="https://twitter.com"
             target="_blank"
             rel="noopener noreferrer"
             whileHover={{ scale: 1.2 }}
-            aria-label="LinkedIn"
+            aria-label="Twitter"
             role="link">
             <i className="fab fa-twitter"></i>  {/* Twitter icon */}
           </SocialIcon>


### PR DESCRIPTION
## Fixes: #371 

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Testing
As it was just a styling issue, no other changes were made that could potentially affect the working of our website.

## Screenshots

**Old screenshots (before adding the hover colors):**

![Screenshot 2025-01-20 214750](https://github.com/user-attachments/assets/93418127-61a8-42a5-9715-d341c57e8bff)
![Screenshot 2025-01-20 221040](https://github.com/user-attachments/assets/bd96a462-302a-44dd-a474-f12eaeda100b)

**New screenshots (after adding their native hover colors):**

![Screenshot 2025-01-20 222019](https://github.com/user-attachments/assets/b33f2bc9-fb16-4ec8-b140-0cfd4f014f2d)
![Screenshot 2025-01-20 222043](https://github.com/user-attachments/assets/efd85d72-1d2f-434c-888b-e9143636c270)


## Checklist
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings


So, this PR fixes the issue described in #371 . Please merge this PR. 
Thanks for your time!
