### PR TITLE
Locked scroll on mobile devices when hamburger menu is opened

### DIFF
--- a/src/componets/Navbar.js
+++ b/src/componets/Navbar.js
@@ -288,6 +288,26 @@ function Navbar() {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.position = 'fixed';
+      document.body.style.top = '0';
+      document.body.style.width = '100%';
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.width = '';
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.width = '';
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
   const handleLogout = () => {
     dispatch(logout());
   };


### PR DESCRIPTION
# Pull Request Template

## Summary
Whenever we use to open the hamburger menu own small screen devices the scroll option was enabled. User could scroll on the hamburger menu and the content behind it would continue to scroll. I locked the scroll option so that whenever the hamburger menu opens only the menu is accessed.

Fixes #386 

## Type of Change
Please mark [X] for applicable items:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Testing
Tested on small screen devices.

## Screenshots/Videos

https://github.com/user-attachments/assets/433f01ca-15ef-4ba0-9290-a9c65fe0cb78



## Checklist
Please mark [X] for completed items:

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation accordingly
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
