### PR TITLE
Fix: Re-added 'Shop' link in navbar

### DIFF
--- a/src/componets/Navbar.js
+++ b/src/componets/Navbar.js
@@ -338,7 +338,10 @@ function Navbar() {
     { title: "About", path: "/about" },
     { title: "Stories", path: "/stories" },
     { title: "Contact", path: "/contact" },
-    { title: "Feedback", path: "/feedback" }
+    { title: "Feedback", path: "/feedback" },
+    { title: "Shop", path: "/shop" },
+    
+
   ];
 
   return (


### PR DESCRIPTION
## Summary
Restored the "Shop" link in the navbar which was missing due to incorrect removal during previous cleanup. This fixes the duplication issue by adding it as a top-level nav item and not inside the Product dropdown.

Fixes #399

## Type of Change
Please mark [X] for applicable items:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other

## Testing
Manually verified on:
- Chrome

Confirmed that the "Shop" link:
- Appears in the top navbar
- Routes correctly to `/shop`
- Is not duplicated in the dropdown

## Screenshots/Videos
THE BUG:-
<img width="1440" height="932" alt="Screenshot 2025-07-28 at 9 49 49 PM" src="https://github.com/user-attachments/assets/82a8c1d4-d1dd-4f1c-b945-99859cc2d312" />

THE BUG FIX:-
<img width="1440" height="932" alt="Screenshot 2025-07-28 at 10 03 45 PM" src="https://github.com/user-attachments/assets/ece374da-9161-4be4-9b1c-2bbae1b54e17" />



## Checklist
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
