### PR TITLE
Feature: Clear Cart button with disable functionality when cart is empty #503

### DIFF
--- a/src/Pages/cart.js
+++ b/src/Pages/cart.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
-import { removeFromCart, updateQuantity, clearCart } from '../Store/cartSlice';
-import styled from 'styled-components';
-import { motion } from 'framer-motion';
-import { toast } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
+import React from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { removeFromCart, updateQuantity, clearCart } from "../Store/cartSlice";
+import styled from "styled-components";
+import { motion } from "framer-motion";
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 const CartContainer = styled.div`
   padding: 2rem;
@@ -116,16 +116,16 @@ function Cart() {
 
   const handleRemoveFromCart = (productId) => {
     dispatch(removeFromCart(productId));
-    toast.error('Item removed from cart!');
+    toast.error("Item removed from cart!");
   };
 
   const handleUpdateQuantity = (productId, quantity) => {
     if (quantity <= 0) {
-      toast.warn('Quantity must be greater than 0');
+      toast.warn("Quantity must be greater than 0");
       return;
     }
     dispatch(updateQuantity({ productId, quantity: parseInt(quantity) }));
-    toast.info('Cart updated!');
+    toast.info("Cart updated!");
   };
 
   const totalPrice = cartItems.reduce(
@@ -138,14 +138,38 @@ function Cart() {
   const finalPrice = totalPrice + SGST + CGST;
 
   const handleProceedToPayment = () => {
-    alert('Payment is processing...');
+    alert("Payment is processing...");
     dispatch(clearCart());
-    toast.success('Thank you for your purchase!');
+    toast.success("Thank you for your purchase!");
   };
 
   return (
     <CartContainer>
       <h1>Your Cart</h1>
+      <RemoveButton
+  whileHover={{ scale: cartItems.length > 0 ? 1.05 : 1 }}
+  whileTap={{ scale: cartItems.length > 0 ? 0.95 : 1 }}
+  onClick={() => {
+    if (cartItems.length === 0) return;
+    const confirmClear = window.confirm(
+      "Are you sure you want to remove all items from the cart?"
+    );
+    if (confirmClear) {
+      dispatch(clearCart());
+      toast.info("All items removed from cart!");
+    }
+  }}
+  disabled={cartItems.length === 0}
+  style={{
+    marginBottom: "1rem",
+    backgroundColor: cartItems.length === 0 ? "#ccc" : "#7c2214",
+    color: cartItems.length === 0 ? "#666" : "#fff",
+    cursor: cartItems.length === 0 ? "not-allowed" : "pointer",
+  }}
+>
+  Clear Cart
+</RemoveButton>
+
       {cartItems.length === 0 ? (
         <p>Your cart is empty. Please add some items!</p>
       ) : (
@@ -177,6 +201,7 @@ function Cart() {
           </CartItem>
         ))
       )}
+
       <SummaryTable>
         <tbody>
           <SummaryRow>


### PR DESCRIPTION
## Summary
Implemented a "Clear Cart" button in the cart page. This button is now:
- Disabled when the cart is empty.
- Enabled when one or more items exist.
- Shows a confirmation prompt before clearing.


## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Code refactor
- [ ] Other

## Testing
- Manually tested on local setup:
  - Button disables when cart is empty
  - Button enables when items are added
  - Confirmation window appears on click


## Screenshots/Videos
<img width="1897" height="924" alt="Screenshot 2025-08-03 224926" src="https://github.com/user-attachments/assets/67d4ae6d-c00f-4a98-83a5-27385dd7d6d1" />


## Checklist
- [x] Code follows project guidelines
- [x] Self-reviewed and tested
- [x] No new warnings or errors
- [x] Feature works as expected
<img width="1823" height="937" alt="Screenshot 2025-08-03 224941" src="https://github.com/user-attachments/assets/d3a33e1a-3675-47ff-aaf3-79942abf74f0" />
<img width="1837" height="912" alt="Screenshot 2025-08-03 225402" src="https://github.com/user-attachments/assets/7f3d3935-ca20-43f2-b3b2-a0160f4bd067" />
